### PR TITLE
Ch store attendant add sale api #161353002

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -5,6 +5,7 @@ from werkzeug.exceptions import NotFound
 v1 = Blueprint('v1', __name__, url_prefix="/api/v1")
 
 from app.api.v1.views.product import end_point as products_end_points
+from app.api.v1.views.sale import end_point as sales_end_points
 #from app.api.v1.views.classname import ClassNames_end_points
 
 api = Api(v1,
@@ -13,4 +14,5 @@ api = Api(v1,
           description="A simple Store mangment system")
 
 api.add_namespace(products_end_points, path="/products/")
+api.add_namespace(sales_end_points, path="/sales/")
 #api.add_namespace(ClassNames_end_points, path="/path")

--- a/app/api/v1/models/sale.py
+++ b/app/api/v1/models/sale.py
@@ -1,16 +1,13 @@
-from app.api.v1.models.product import Product
-product = Product()
-
 class Sale:
-    sales = {}
-    length = 0
-
     def __init__(self):
-        pass
+        self.sales = {}
+        self.length = 0
+        self.id = 0
+        self.product_id = 0
+        self.name = ''
+        self.cost = 0
 
     def add(self, product_id, name, cost, amount):
-        # if not self.sale(product_id,amount):
-        #     return self
         self.length += 1
         self.id = self.length
         self.product_id = product_id
@@ -23,10 +20,6 @@ class Sale:
         }
         return self
 
-    def sale(self, product_id, amount):
-        item = product.get(product_id)
-        print(item['amount'])
-
     def get(self, id):
         sale = self.sales[id]
         return {
@@ -38,8 +31,10 @@ class Sale:
     def get_all(self):
         return self.sales
 
-    def update(self, data):
-        self.sales[data.id].update(data)
+    def update(self, id, data):
+        if id:
+            self.sales[id].update(data)
 
     def delete(self, id):
-        self.sales.pop(id)
+        if id:
+            self.sales.pop(id)

--- a/app/api/v1/views/sale.py
+++ b/app/api/v1/views/sale.py
@@ -28,4 +28,12 @@ sale_message = end_point.model('sale message', {
 
 @end_point.route('')
 class Sale(Resource):
-    pass
+    @end_point.expect(a_sale)
+    @end_point.doc('create a sale')
+    @end_point.marshal_with(sale_message, code=201)
+    def post(self):
+        data = end_point.payload
+        sale.add(data['product_id'], data['name'], data['cost'], data['amount'])
+        return {'message': 'success',
+                'sale': sale.get(sale.id)
+                }, 201

--- a/app/api/v1/views/sale.py
+++ b/app/api/v1/views/sale.py
@@ -1,0 +1,31 @@
+from flask_restplus import Namespace, fields
+from flask_restplus import Resource
+
+from ..models.sale import Sale as SaleModel
+
+sale = SaleModel()
+
+end_point = Namespace('sales', description='sales resources')
+
+sale_id = fields.Integer(required=True,description="The product id")
+
+a_sale = end_point.model('sale', {
+    'product_id': sale_id,
+    'name': fields.String(required=True, description="The sales name"),
+    'cost': fields.Integer(required=True, description="The sales cost"),
+    'amount': fields.Integer(description="The amount of items to be sold")
+})
+
+sales = end_point.model('sales', {sale_id: fields.Nested(a_sale)})
+
+message = end_point.model('message', {'message': fields.String(required=True, description="success or fail message")})
+
+sale_message = end_point.model('sale message', {
+    'message': fields.String(required=True, description="success or fail message"),
+    'sale': fields.Nested(a_sale)
+})
+
+
+@end_point.route('')
+class Sale(Resource):
+    pass

--- a/app/test/v1/test_sale.py
+++ b/app/test/v1/test_sale.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+from app import create_app
+import json
+
+
+class TestSale(TestCase):
+    def setUp(self):
+        self.app = create_app('testing')
+        self.client = self.app.test_client()
+        self.sale = {'product_id': 1, 'name': 'sugar', 'cost': 10, 'amount': 1}
+
+    def test_add_sale(self):
+        path = '/api/v1/sales/'
+        data = json.dumps(self.sale)
+        # self.assertEqual(data, self.client.get('/api/v1/products/1').json['product'])
+        result = self.client.post(
+            path, data=data, content_type='application/json')
+        self.assertEqual(201, result.status_code)
+        self.assertEqual('success', result.json['message'])
+        self.assertTrue(result.json['sale'])
+
+    def test_get_all_sales(self):
+        path = '/api/v1/sales'
+        result = self.client.get(path)
+        self.assertEqual(200, result.status_code)
+        self.assertEqual('success', result.json['message'])
+        self.assertTrue(result.json['sales'])
+
+    def test_get_sales(self):
+        path = '/api/v1/sales/1'
+        result = self.client.get(path)
+        self.assertEqual(200, result.status_code)
+        self.assertEqual('success', result.json['message'])
+        self.assertTrue(result.json['sale'])


### PR DESCRIPTION
#### What does this PR do?
Gives an admin or store attendant the ability to add a sale order.

#### Description of Task to be completed?
The endpoint 'POST /sales/' used to add a sale order.

#### How should this be manually tested?
Clone this repository
git clone https://github.com/dbuturu/Store-Manager.git
Check out this branch.
git checkout ch-Store_attendant_add_sale-API-#161353002
Create a virtual environment
virtualenv venv
Active it by a run active command
source venv/bin/activate 
source venv/Scripts/activate 
venv\activate.bat 
Install dependencies
pip install -r requirements.txt
Start the application.
python run.py
Run Tests
pytest -v

#### Any background context you want to provide?
This is an API chore

#### What are the relevant pivotal tracker stories?
#161353002